### PR TITLE
Add devcontainer configuration for Amiga development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,54 @@
+# Optional custom Dockerfile for additional setup
+# This extends the base amigadev/crosstools:m68k-amigaos image
+
+FROM amigadev/crosstools:m68k-amigaos
+
+# Install additional development tools
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    make \
+    ninja-build \
+    gdb \
+    valgrind \
+    vim \
+    nano \
+    tree \
+    htop \
+    curl \
+    wget \
+    zip \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up environment variables for Amiga development
+ENV AMIGA_TOOLCHAIN=/opt/amiga
+ENV TOOLCHAIN_PATH=/opt/amiga
+ENV CC=m68k-amigaos-gcc
+ENV CXX=m68k-amigaos-gcc
+ENV AR=m68k-amigaos-ar
+ENV STRIP=m68k-amigaos-strip
+ENV OBJDUMP=m68k-amigaos-objdump
+
+# Create a non-root user for development
+RUN useradd -m -s /bin/bash vscode && \
+    usermod -aG sudo vscode && \
+    echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Set the working directory
+WORKDIR /workspace
+
+# Switch to the vscode user
+USER vscode
+
+# Add helpful aliases
+RUN echo 'alias ll="ls -la"' >> ~/.bashrc && \
+    echo 'alias la="ls -A"' >> ~/.bashrc && \
+    echo 'alias l="ls -CF"' >> ~/.bashrc && \
+    echo 'alias agcc="m68k-amigaos-gcc"' >> ~/.bashrc && \
+    echo 'alias amake="make CC=m68k-amigaos-gcc"' >> ~/.bashrc
+
+# Display toolchain info on login
+RUN echo 'echo "Amiga m68k toolchain ready:"' >> ~/.bashrc && \
+    echo 'echo "Compiler: $(m68k-amigaos-gcc --version | head -1)"' >> ~/.bashrc && \
+    echo 'echo "Toolchain path: $AMIGA_TOOLCHAIN"' >> ~/.bashrc

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,89 @@
+# AWeb Amiga Development Container
+
+This devcontainer provides a complete development environment for building AWeb using the Amiga m68k cross-compilation toolchain.
+
+## Features
+
+- **Base Image**: `amigadev/crosstools:m68k-amigaos` - Pre-configured Amiga cross-compilation environment
+- **Compiler**: m68k-amigaos-gcc (Bartman's GCC port)
+- **Build System**: CMake + Make support
+- **IDE Integration**: VS Code with C/C++ extensions and IntelliSense configured
+
+## Quick Start
+
+1. **Open in VS Code**: Click "Reopen in Container" when prompted, or use Command Palette > "Dev Containers: Reopen in Container"
+
+2. **Build the project**:
+   ```bash
+   # Configure CMake with the Amiga toolchain
+   cmake -DCMAKE_TOOLCHAIN_FILE=toolchain/m68k-bartmanjob.cmake .
+
+   # Build
+   make
+   ```
+
+3. **Alternative build with Make**:
+   ```bash
+   # Use the traditional Makefile if preferred
+   make -f Makefile
+   ```
+
+## Environment Variables
+
+The container sets up the following environment variables:
+
+- `AMIGA_TOOLCHAIN=/opt/amiga` - Path to the Amiga toolchain
+- `CC=m68k-amigaos-gcc` - C compiler
+- `CXX=m68k-amigaos-gcc` - C++ compiler (same as C for Amiga)
+- `TOOLCHAIN_PATH=/opt/amiga` - Toolchain path for CMake
+
+## Helpful Aliases
+
+- `agcc` - Shortcut for `m68k-amigaos-gcc`
+- `amake` - Make with correct compiler set
+
+## VS Code Configuration
+
+The devcontainer automatically configures:
+
+- **IntelliSense**: Recognizes Amiga-specific headers and defines
+- **CMake Tools**: Integration for building and debugging
+- **C/C++ Extension**: Proper syntax highlighting and code completion
+
+### Key Settings Applied
+
+- Compiler path: `/opt/amiga/bin/m68k-amigaos-gcc`
+- Include paths: Project headers + Amiga system headers
+- Defines: `AMIGA`, `__amigaos__`, `__stdargs=`, `__saveds=`, `BARTMAN_GCC`
+
+## Toolchain Details
+
+This environment uses the Bartman GCC toolchain specifically designed for Amiga development:
+
+- **Target**: m68k-amigaos (68000 processor)
+- **System Headers**: Located in `/opt/amiga/m68k-amigaos/sys-include`
+- **Libraries**: Amiga system libraries and C runtime
+
+## Project Structure Support
+
+The devcontainer is configured to work with AWeb's structure:
+
+- Main source: `aweb/`
+- Libraries: `aweblibs/`
+- Configuration: `awebcfg/`
+- Platform headers: `Include/`
+- Toolchain: `toolchain/` (git submodule)
+
+## Troubleshooting
+
+### Build Issues
+- Ensure the toolchain submodule is initialized: `git submodule update --init`
+- Verify CMake uses the correct toolchain: Check that `-DCMAKE_TOOLCHAIN_FILE` points to the right file
+
+### VS Code Issues
+- Reload window if IntelliSense doesn't work: `Ctrl+Shift+P` > "Developer: Reload Window"
+- Check that the C/C++ extension is active
+
+### Container Issues
+- Rebuild container: `Ctrl+Shift+P` > "Dev Containers: Rebuild Container"
+- Check Docker is running and has sufficient resources

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,82 @@
+{
+    "name": "AWeb Amiga Development",
+    "image": "amigadev/crosstools:m68k-amigaos",
+
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": true,
+            "configureZshAsDefaultShell": true,
+            "installOhMyZsh": true,
+            "upgradePackages": true,
+            "username": "vscode",
+            "userUid": "automatic",
+            "userGid": "automatic"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "ppa": true,
+            "version": "latest"
+        }
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cpptools-extension-pack",
+                "ms-vscode.cmake-tools",
+                "twxs.cmake",
+                "ms-vscode.hexeditor",
+                "streetsidesoftware.code-spell-checker"
+            ],
+            "settings": {
+                "cmake.configureOnOpen": false,
+                "cmake.generator": "Unix Makefiles",
+                "cmake.preferredGenerators": ["Unix Makefiles"],
+                "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+                "C_Cpp.default.compilerPath": "/opt/amiga/bin/m68k-amigaos-gcc",
+                "C_Cpp.default.intelliSenseMode": "gcc-x86",
+                "C_Cpp.default.cStandard": "c11",
+                "C_Cpp.default.defines": [
+                    "AMIGA",
+                    "__amigaos__",
+                    "__stdargs=",
+                    "__saveds=",
+                    "BARTMAN_GCC"
+                ],
+                "C_Cpp.default.includePath": [
+                    "${workspaceFolder}/Include",
+                    "${workspaceFolder}/aweb/include",
+                    "${workspaceFolder}/aweblibs/include",
+                    "${workspaceFolder}/libs/library",
+                    "${workspaceFolder}/libs/library/include",
+                    "/opt/amiga/m68k-amigaos/sys-include",
+                    "/opt/amiga/m68k-amigaos/include"
+                ],
+                "files.associations": {
+                    "*.h": "c",
+                    "*.c": "c"
+                }
+            }
+        }
+    },
+
+    "remoteEnv": {
+        "CC": "m68k-amigaos-gcc",
+        "CXX": "m68k-amigaos-gcc",
+        "AMIGA_TOOLCHAIN": "/opt/amiga",
+        "TOOLCHAIN_PATH": "/opt/amiga"
+    },
+
+    "mounts": [
+        "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
+    ],
+
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+    "workspaceFolder": "/workspace",
+
+    "postCreateCommand": "echo 'AWeb Amiga development environment ready!' && m68k-amigaos-gcc --version",
+
+    "forwardPorts": [],
+
+    "shutdownAction": "stopContainer"
+}


### PR DESCRIPTION
- Uses amigadev/crosstools:m68k-amigaos Docker image
- Pre-configured VS Code extensions and settings
- IntelliSense support for Amiga-specific code (__saveds, __stdargs)
- CMake and Make build support
- Complete development environment documentation

🤖 Generated with [Claude Code](https://claude.ai/code)